### PR TITLE
4.19 update combined with change of URI path handling for Android API versions 23+ (android 6.0+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+Android Sharing plugin from PandoraEntertainment
+
+https://forums.unrealengine.com/community/community-content-tools-and-tutorials/100009-free-adcolony-applovin-chartboost-unityads-vungle-sharing-onesignal-facebook-everyplay
+
+Updated to work with 4.19 and Android versions newer than android-23 (android 6.0 +)
+
+NOTE: Untested on older versions of Android!

--- a/Source/Sharing/Sharing.Build.cs
+++ b/Source/Sharing/Sharing.Build.cs
@@ -1,39 +1,38 @@
-
-
 using System.IO;
 
 namespace UnrealBuildTool.Rules
 {
-	public class Sharing : ModuleRules
-	{
-		public Sharing(TargetInfo Target)
-		{
-			PublicIncludePaths.AddRange(
-				new string[] {
-					// ... add public include paths required here ...
-				}
-				);
+    public class Sharing : ModuleRules
+    {
+        public Sharing(ReadOnlyTargetRules Target) : base (Target)
+        {
+            PublicIncludePaths.AddRange(
+                new string[] {
+                    // ... add public include paths required here ...
+                }
+                );
 
-			PrivateIncludePaths.AddRange(
-				new string[] {
-					"Developer/Sharing/Private",
-					// ... add other private include paths required here ...
-				}
-				);
+            PrivateIncludePaths.AddRange(
+                new string[] {
+                    "Developer/Sharing/Private",
+                    // ... add other private include paths required here ...
+                }
+                );
 
-			PublicDependencyModuleNames.AddRange(
-				new string[]
-				{
-					"Core",
-					"CoreUObject",
-					"Engine"
-					// ... add other public dependencies that you statically link with here ...
-				}
-				);
+            PublicDependencyModuleNames.AddRange(
+                new string[]
+                {
+                    "Core",
+                    "CoreUObject",
+                    "Engine",
+                    "ImageWrapper"
+                    // ... add other public dependencies that you statically link with here ...
+                }
+                );
 
-			PrivateDependencyModuleNames.AddRange(
-				new string[]
-				{
+            PrivateDependencyModuleNames.AddRange(
+                new string[]
+                {
                     //"CoreUObject",
                     //"Engine",
                     //"InputCore",
@@ -44,42 +43,45 @@ namespace UnrealBuildTool.Rules
                     //"HTTP",
 
                     //"UMG", "Slate", "SlateCore",
-                    //"ImageWrapper",               
-					// ... add private dependencies that you statically link with here ...
-				}
-				);
+                    //"ImageWrapper",              
+                    // ... add private dependencies that you statically link with here ...
+                }
+                );
 
-			DynamicallyLoadedModuleNames.AddRange(
-				new string[]
-				{
-					// ... add any modules that your module loads dynamically here ...
-				}
-				);
-				
-			PrivateIncludePathModuleNames.AddRange(
-			new string[] {
-				"Settings",
+            DynamicallyLoadedModuleNames.AddRange(
+                new string[]
+                {
+                    // ... add any modules that your module loads dynamically here ...
+                }
+                );
+
+            PrivateIncludePathModuleNames.AddRange(
+            new string[] {
+                "Settings",
                 "Launch",
             }
             );
 
 
-			if (Target.Platform == UnrealTargetPlatform.IOS) {
-				
-			
+            if (Target.Platform == UnrealTargetPlatform.IOS) {
 
-				PublicFrameworks.AddRange( 
-					new string[] 
-					{ 
-						
-					}
-				);
+
+
+                PublicFrameworks.AddRange(
+                    new string[]
+                    {
+
+                    }
+                );
+            }
+            else if(Target.Platform == UnrealTargetPlatform.Android) 
+			{ 
+				PrivateDependencyModuleNames.AddRange(new string[] { "Launch" });  
+				string PluginPath = Utils.MakePathRelativeTo(ModuleDirectory, Target.RelativeEnginePath); 
+				AdditionalPropertiesForReceipt.Add("AndroidPlugin", Path.Combine(PluginPath, "Sharing_APL.xml"));
+				//string PluginPath = Utils.MakePathRelativeTo(ModuleDirectory, BuildConfiguration.RelativeEnginePath); 
+				//AdditionalPropertiesForReceipt.Add(new ReceiptProperty("AndroidPlugin", Path.Combine(PluginPath, "Sharing_APL.xml"))); 
 			}
-			else if(Target.Platform == UnrealTargetPlatform.Android)
-			{
-				string PluginPath = Utils.MakePathRelativeTo(ModuleDirectory, BuildConfiguration.RelativeEnginePath);
-				AdditionalPropertiesForReceipt.Add(new ReceiptProperty("AndroidPlugin", Path.Combine(PluginPath, "Sharing_APL.xml")));
-			}
-		}
-	}
+        }
+    }
 }

--- a/Source/Sharing/Sharing_APL.xml
+++ b/Source/Sharing/Sharing_APL.xml
@@ -10,15 +10,15 @@
 
   <androidManifestUpdates>
     <addElements tag="application">
-      <!--<provider 
+      <provider 
       android:name="android.support.v4.content.FileProvider"
-      android:authorities="com.MyCompany.MyGame.fileprovider"
+      android:authorities="${applicationId}.fileprovider"
       android:exported="false"
       android:grantUriPermissions="true">
        <meta-data
         android:name="android.support.FILE_PROVIDER_PATHS"
         android:resource="@xml/file_paths"/> 
-      </provider>-->
+      </provider>
     </addElements>   
   </androidManifestUpdates>
 
@@ -33,8 +33,8 @@
 
   <!-- optional files or directories to copy to Intermediate/Android/APK -->
   <resourceCopies>
-    <!-- Copy the generated resource file to be packaged 
-    <copyFile src="$S(PluginDir)/../../lib/Android/res/file_paths.xml" dst="$S(BuildDir)/res/xml/file_paths.xml" />-->
+    <!-- Copy the generated resource file to be packaged -->
+    <copyFile src="$S(PluginDir)/../../lib/Android/res/file_paths.xml" dst="$S(BuildDir)/res/xml/file_paths.xml" />
    
   </resourceCopies>
 
@@ -59,7 +59,7 @@
       //File picDir  = new File("../../../RisingBirds/Saved/Screenshots/Android" + "/myPic");
       //File picFile = new File(picDir + "/" + "Game" + ".png");
 
-      // Method to share either text or URL.
+      // Method to share either text or URL ******************************************************************
       //private void AndroidThunkJava_Sharing_ShareTextUrl(String Subject, String Message, String Url) {}
 
 
@@ -84,7 +84,7 @@
       }
 
 
-      //Method to share Text and image
+      //Method to share Text and image **********************************************************************************************
 
       private void AndroidThunkJava_Sharing_ShareScreenshotText(String Subject, String Message, String AppName, String Filename  ) {
 
@@ -93,7 +93,7 @@
       String MessageText = Message;
 
 
-      //Log.debug("Package Name is" + getPackageName());
+      Log.debug("Package Name is" + getPackageName());
 
 
       //Log.debug("Data Directory is" + getFilesDir().getAbsolutePath()); //getFilesDir().getAbsolutePath(),Environment.getDataDirectory()
@@ -117,11 +117,15 @@
       File picFile = new File(dirpath.getPath(), "UE4Game" +"/" + AppName + "/" + AppName + "/" + "Saved/Screenshots/Android" + "/" + Filename);
       //Log.debug("picFile is" + "/" + picFile.toString() + picFile.exists());
 
+	  String str = Environment.getExternalStorageDirectory().getAbsolutePath();
+	  //Log.debug("get enviroment path " + str.toString());
+      
+	  Log.debug("about to call uri");
+      //Uri uri = FileProvider.getUriForFile(this, "com.YourCompany.shareTest.fileprovider", picFile); //File provider
+  	  Uri uri = FileProvider.getUriForFile(this, getPackageName() + ".fileprovider", picFile); //File provider
+	  Log.debug("UriName is" + "/" + uri.toString());
 
-      //Uri uri = FileProvider.getUriForFile(this, "com.PandoraEntertainmentLtd.RisingBirds.fileprovider", picFile); //File provider
-      //Log.debug("UriName is" + "/" + uri.toString());
-
-
+	  
       //Log.debug("Root Directory is" + Environment.getRootDirectory()); //getDataDirectory()
       //Log.debug("External Directory is" + Environment.getExternalStorageDirectory()); //picDir.getAbsolutePath()
 
@@ -133,19 +137,22 @@
       //intent.putExtra(Intent.EXTRA_SUBJECT, shareNote.getTitle());
       //intent.putExtra(Intent.EXTRA_TEXT, shareNote.getTitle());
       intent.setType("image/*");
-      intent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(picFile));
+      //The two commented out under this one are the old intents for the image
+	  intent.putExtra(Intent.EXTRA_STREAM, uri);
+	  Log.debug("Intent Placed");
+      //intent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(picFile));
       //intent.putExtra(Intent.EXTRA_STREAM, Uri.parse(picFile.getAbsolutePath()));
       intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
       startActivity(Intent.createChooser(intent, "Share via"));
       //this.startActivity(intent);
-
+Log.debug("chooser shown");
       }
 
       /////////////////////////////////
 
       /*
 
-      // Method to share any image.
+      // Method to share any image. NOT USED???
       private void AndroidThunkJava_Sharing_shareImage() {
       Intent share = new Intent(Intent.ACTION_SEND);
 
@@ -155,12 +162,13 @@
 
       // Make sure you put example png image named myImage.png in your
       // directory
-      String imagePath = Environment.getExternalStorageDirectory()
-      + "/myImage.png";
+      //String imagePath = Environment.getExternalStorageDirectory() + "/myImage.png";
 
-      File imageFileToShare = new File(imagePath);
+      //File imageFileToShare = new File(imagePath);
 
-      Uri uri = Uri.fromFile(imageFileToShare);
+      //Uri uri = Uri.fromFile(imageFileToShare);
+	  Uri uri = FileProvider.getUriForFile(this, "${applicationId}.fileprovider", picFile); //File provider
+      Log.debug("We are here! UriName is" + "/" + uri.toString());
       share.putExtra(Intent.EXTRA_STREAM, uri);
 
       startActivity(Intent.createChooser(share, "Share Image!"));
@@ -187,6 +195,7 @@
       if (!picDir.exists())
       {
       picDir.mkdir();
+	  Log.debug("created mkdir: " + picDir.toString());
       }
       view.setDrawingCacheEnabled(true);
       view.buildDrawingCache(true);
@@ -227,7 +236,8 @@
       sharingIntent.putExtra(Intent.EXTRA_SUBJECT, Title);
       sharingIntent.putExtra(Intent.EXTRA_TEXT, Link);
       sharingIntent.setType("image/jpeg");
-      sharingIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse(picFile.getAbsolutePath()));
+      //sharingIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse(picFile.getAbsolutePath()));
+	  Log.debug("incorrect do not use");
       startActivity(Intent.createChooser(sharingIntent, "Share via"));
       }
 

--- a/lib/Android/res/file_paths.xml
+++ b/lib/Android/res/file_paths.xml
@@ -1,12 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<paths>
-    <files-path
-        name="internal_images"
-        path="images/" />
-    <external-path
-        name="external_images"
-        path="images" />
-    <cache-path
-        name="cache_images"
-        path="docs/" />
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
 </paths>


### PR DESCRIPTION
**Note:** untested on older Android versions (ie; under version 6.0 so no idea if they still work or not. If not there needs to be a IF statement in there to switch the uri var depending on the current Android API of the device.